### PR TITLE
Remove Multidex usages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,6 @@ android {
         release {
             minifyEnabled false
             shrinkResources false
-            multiDexEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
@@ -123,7 +122,6 @@ dependencies {
     }
 
     coreLibraryDesugaring libs.desugar.jdk.libs
-    implementation libs.androidx.multidex
 
     implementation platform(libs.okhttp.bom)
     implementation libs.okhttp.client

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ material = "1.9.0"
 swiperefreshlayout = "1.1.0"
 browser = "1.5.0"
 exifinterface = "1.3.6"
-multidex = "2.0.1"
 installreferrer = "2.2"
 constraintlayout = "2.1.4"
 
@@ -40,7 +39,6 @@ androidx-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx"
 
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
-androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version = "1.0.0" }
 
@@ -77,7 +75,6 @@ test-androidx-test-runner = { module = "androidx.test:runner", version = "1.5.2"
 test-androidx-test-rules = { module = "androidx.test:rules", version = "1.5.0" }
 test-androidx-test-junit-ktx = { module = "androidx.test.ext:junit-ktx", version = "1.1.5" }
 test-androidx-core-testing = { module = "androidx.arch.core:core-testing", version = "2.2.0" }
-test-androidx-multidex-instrumentation = { module = "androidx.multidex:multidex-instrumentation", version.ref = "multidex" }
 test-hamcrest = { module = "org.hamcrest:hamcrest", version = "2.2" }
 test-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 test-dagger-hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "dagger" }
@@ -88,7 +85,6 @@ test-mockito-android = { module = "org.mockito:mockito-android", version.ref = "
 test-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito" }
 
 test-robolectric-client = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-test-robolectric-shadows-multidex = { module = "org.robolectric:shadows-multidex", version.ref = "robolectric" }
 
 test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 test-espresso-contrib = { module = "androidx.test.espresso:espresso-contrib", version.ref = "espresso" }


### PR DESCRIPTION
Since the min SDK is 23, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l